### PR TITLE
Remove hardcoded psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django==4.2.19
-psycopg2-binary==2.9.9
+psycopg2-binary
 gunicorn==23.0.0
 django-cors-headers==4.7.0
 requests==2.32.3


### PR DESCRIPTION
The current 2.9.10 version at least builds, 2.9.9 does not.